### PR TITLE
Allow for h-cards without a photo.

### DIFF
--- a/lib/indieweb/authorship.rb
+++ b/lib/indieweb/authorship.rb
@@ -35,7 +35,7 @@ module Indieweb
           return hcard_data_for(
             URI.join(url, hcard['properties']['url'][0]).to_s,
             hcard['properties']['name'][0],
-            URI.join(url, hcard['properties']['photo'][0]).to_s
+            hcard['properties'].key?('photo') ? URI.join(url, hcard['properties']['photo'][0]).to_s : nil
           )
 
         # 5.2. otherwise if author property is an http(s) URL, let the

--- a/spec/examples/h-entry-has-h-card-with-no-photo
+++ b/spec/examples/h-entry-has-h-card-with-no-photo
@@ -1,0 +1,27 @@
+HTTP/1.1 200 OK
+Server: Apache
+Date: Wed, 09 Dec 2015 03:29:14 GMT
+Content-Type: text/html; charset=utf-8
+
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Example</title>
+</head>
+<body>
+
+  <div class="h-entry">
+
+    <div class="p-author h-card">
+      <a href="/about" class="u-url">
+        <span class="p-name">Author</span>
+      </a>
+    </div>
+
+    <p class="p-name e-content">Hello World</p>
+    
+  </div>
+
+</body>
+</html>

--- a/spec/h-entry-has-h-card-with-no-photo_spec.rb
+++ b/spec/h-entry-has-h-card-with-no-photo_spec.rb
@@ -1,0 +1,26 @@
+RSpec.describe Indieweb::Authorship do
+  let(:page) { 'h-entry-has-h-card-with-no-photo' }
+  let(:url) { "http://author.example.com/#{page}" }
+  let(:html) { html_for(page) }
+  let(:linked_url) { 'http://author.example.com/about' }
+  let(:expected_data) do
+    {
+      'url' => 'http://author.example.com/about',
+      'name' => 'Author',
+      'photo' => nil
+    }
+  end
+
+  before do
+    allow(Net::HTTP).to receive(:get).with(URI(url)) { html }
+    allow(Net::HTTP).to receive(:get).with(linked_url) { html_for('about') }
+  end
+
+  context 'when given just a URL' do
+    it { expect(described_class.identify(url)).to eq expected_data }
+  end
+
+  context 'when given both a URL and HTML' do
+    it { expect(described_class.identify(url, html)).to eq expected_data }
+  end
+end


### PR DESCRIPTION
Hi Stephen 👋. I was using your authorship gem with an h-card which didn't have a photo and was throwing an exception. This was from Ana's post at https://ohhelloana.blog/indiewebcamp-london

This PR adds a test for the condition and modifies the identify method so it doesn't try to include a photo property if there isn't a photo.